### PR TITLE
Add a save method to the _Model protocol

### DIFF
--- a/Sources/Meow/Model.swift
+++ b/Sources/Meow/Model.swift
@@ -3,6 +3,9 @@ import MongoKitten
 
 /// Private base protocol for `Model` without Self or associated type requirements
 public protocol _Model: class, Codable {
+    /// Saves the instance to the given context, calling `context.save(self)`
+    func save(to context: Context) -> EventLoopFuture<Void>
+    
     // MARK: - Serialization
     
     /// The collection name instances of the model live in. A default implementation is provided.
@@ -26,6 +29,10 @@ public protocol Model: _Model {
 
 // MARK: - Default implementations
 public extension Model {
+    public func save(to context: Context) -> EventLoopFuture<Void> {
+        return context.save(self)
+    }
+    
     static var collectionName: String {
         return String(describing: Self.self) // Will be the name of the type
     }


### PR DESCRIPTION
This PR adds a `save` method to the `_Model` protocol. It also adds a default implementation of the method to the `Model` protocol.

Because the `_Model` protocol is not meant to be directly conformed to, this change can be considered as purely additive and non-breaking.

### Motivation

The `Model` protocol has an associated type requirement (`Identifier`). There are cases where you want to perform a save operation on a Model, while the exact type is unknown. With this PR, you can:

```swift
let maybeAModel: Any = ...
if let model = maybeAModel as? _Model {
    model.save(to: context)
}
```