### PR TITLE
Conform Context and Manager to EventLoopGroup

### DIFF
--- a/Sources/Meow/Context.swift
+++ b/Sources/Meow/Context.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MongoKitten
 import NIO
+import Dispatch
 
 // A 🐈 Context
 public final class Context {

--- a/Sources/Meow/Context.swift
+++ b/Sources/Meow/Context.swift
@@ -329,6 +329,16 @@ public final class Context {
     }
 }
 
+extension Context: EventLoopGroup {
+    public func shutdownGracefully(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) {
+        eventLoop.shutdownGracefully(queue: queue, callback)
+    }
+    
+    public func next() -> EventLoop {
+        return self.eventLoop
+    }
+}
+
 public enum DecodeResult<M> {
     case success(M)
     case failure(Error, Document)

--- a/Sources/Meow/Manager.swift
+++ b/Sources/Meow/Manager.swift
@@ -1,5 +1,6 @@
 @_exported import MongoKitten
 import NIO
+import Dispatch
 
 /// A Meow
 public final class Manager {
@@ -19,4 +20,14 @@ public final class Manager {
         return database[M.collectionName]
     }
     
+}
+
+extension Manager: EventLoopGroup {
+    public func next() -> EventLoop {
+        return self.eventLoop
+    }
+    
+    public func shutdownGracefully(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) {
+        eventLoop.shutdownGracefully(queue: queue, callback)
+    }
 }


### PR DESCRIPTION
This PR makes `Context` and `Manager` to the `EventLoopGroup` protocol from NIO.

This allows you to use `Context` and `Manager` everywhere a `EventLoopGroup` can be used.

### Motivation

I'm working on the upcoming OpenKitten Factory library. With this PR, it is easier to use Meow with the Factory library.